### PR TITLE
Add MCP server configuration for Claude Code

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - `make vscode-install` - Install VS Code extensions from extensions.txt
 - `make vscode-save` - Save current VS Code extensions to extensions.txt
 - `make asdf-setup` - Install and configure asdf language plugins
+- `make mcp-setup` - Install user-scope MCP servers for Claude Code
 
 ### Development Environment
 - `asdf install` - Install language versions specified in .tool-versions
@@ -42,6 +43,8 @@ This is a personal dotfiles repository that uses **dotbot** for installation man
 - `claude/` - Global Claude Code commands and settings for installation (symlinked to user's global claude directory)
   - `claude/commands/` - Custom slash commands including task-manager and create-prd
   - `claude/settings.json` - Claude Code settings with telemetry disabled
+  - `claude/mcp-servers.json` - Documentation of common user-scope MCP servers
+  - `claude/install-mcp.sh` - Script to install user-scope MCP servers
 
 ### Installation Flow
 1. Dotbot updates git submodules recursively

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Declare phony targets (commands, not files)
-.PHONY: install link brew vscode-install vscode-save backup asdf-setup
+.PHONY: install link brew vscode-install vscode-save backup asdf-setup mcp-setup
 
 # Run dotbot install script
 install:
@@ -35,3 +35,7 @@ backup:
 # Setup asdf language plugins
 asdf-setup:
 	./config/asdf/setup-asdf.sh
+
+# Setup MCP servers for Claude Code
+mcp-setup:
+	./claude/install-mcp.sh

--- a/claude/install-mcp.sh
+++ b/claude/install-mcp.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+# Install MCP servers for Claude Code (user scope)
+# This script configures the MCP servers defined in mcp.json
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MCP_CONFIG_FILE="$SCRIPT_DIR/mcp-servers.json"
+
+echo "🔧 Installing MCP servers for Claude Code..."
+
+# Check if Claude Code is available
+if ! command -v claude &> /dev/null; then
+    echo "❌ Claude Code CLI not found. Please install Claude Code first."
+    echo "   Visit: https://docs.anthropic.com/en/docs/claude-code"
+    exit 1
+fi
+
+# Check if MCP config file exists
+if [[ ! -f "$MCP_CONFIG_FILE" ]]; then
+    echo "❌ MCP configuration file not found: $MCP_CONFIG_FILE"
+    exit 1
+fi
+
+echo "📋 Found MCP configuration file: $MCP_CONFIG_FILE"
+
+# Install Context7 server
+echo "🌐 Installing Context7 MCP server..."
+claude mcp add --scope user --transport http context7 https://mcp.context7.com/mcp || {
+    echo "⚠️  Failed to install Context7 server (may already exist)"
+}
+
+# Install Sequential Thinking server
+echo "🧠 Installing Sequential Thinking MCP server..."
+claude mcp add --scope user sequential-thinking npx @modelcontextprotocol/server-sequential-thinking || {
+    echo "⚠️  Failed to install Sequential Thinking server (may already exist)"
+}
+
+echo "✅ MCP server installation complete!"
+echo ""
+echo "📝 To verify installation, run:"
+echo "   claude mcp list"
+echo ""
+echo "🔍 To check server status:"
+echo "   claude mcp get context7"
+echo "   claude mcp get sequential-thinking"

--- a/claude/mcp-servers.json
+++ b/claude/mcp-servers.json
@@ -1,0 +1,14 @@
+{
+  "description": "Common MCP servers for Claude Code (user scope)",
+  "note": "These servers are installed at user scope using install-mcp.sh script",
+  "servers": {
+    "context7": {
+      "command": "claude mcp add --scope user --transport http context7 https://mcp.context7.com/mcp",
+      "description": "Context7 MCP server for enhanced context management and retrieval"
+    },
+    "sequential-thinking": {
+      "command": "claude mcp add --scope user sequential-thinking npx @modelcontextprotocol/server-sequential-thinking",
+      "description": "Official MCP server for dynamic and reflective problem-solving through structured thinking"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Add user-scope MCP server configuration for Claude Code with common servers for cross-environment sharing.

## Features Added
- **Context7 MCP server**: Enhanced context management and retrieval
- **Sequential Thinking MCP server**: Official server for structured problem-solving
- **Automated installation**: Script and Makefile target for easy setup

## Changes Made
- Added `claude/mcp-servers.json` - Documentation of MCP server configurations
- Added `claude/install-mcp.sh` - Installation script for user-scope MCP servers
- Added `make mcp-setup` - Makefile target for MCP server installation
- Updated `CLAUDE.md` - Added MCP configuration documentation

## Usage
Run `make mcp-setup` to install both MCP servers in user scope, making them available across all Claude Code projects.

## Test Plan
- [x] Verified Context7 server installation
- [x] Verified Sequential Thinking server installation
- [x] Confirmed no conflicts with Claude Desktop configuration
- [x] Tested `make mcp-setup` command execution