### PR TITLE
Harden and simplify core CLI config defaults

### DIFF
--- a/config/asdf/setup-asdf.sh
+++ b/config/asdf/setup-asdf.sh
@@ -45,7 +45,7 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
         # Dependencies for Python and Ruby compilation
         brew list openssl &> /dev/null || brew install openssl
         brew list readline &> /dev/null || brew install readline
-        brew list sqlite3 &> /dev/null || brew install sqlite3
+        brew list sqlite &> /dev/null || brew install sqlite
         brew list xz &> /dev/null || brew install xz
         brew list zlib &> /dev/null || brew install zlib
         print_success "Build dependencies installed"

--- a/config/git/git
+++ b/config/git/git
@@ -86,4 +86,4 @@
 [init]
 	defaultBranch = main
 [credential]
-	helper = manager-core
+	helper = osxkeychain

--- a/config/git/gitignore_global
+++ b/config/git/gitignore_global
@@ -147,7 +147,6 @@ vendor/bundle
 lib/bundler/man
 .rbenv-version
 .rvmrc
-.ruby-version
 .ruby-gemset
 
 # Go
@@ -164,7 +163,6 @@ vendor/
 # Rust
 /target/
 **/*.rs.bk
-Cargo.lock
 
 # Java
 *.class
@@ -348,22 +346,8 @@ temp/
 *.zip
 
 ################
-# Version Management
-################
-
-# asdf
-.tool-versions
-
-# rbenv
-.ruby-version
-
-# pyenv
-.python-version
-
-# nvm
-.nvmrc
-
 # Terraform
+################
 *.tfstate
 *.tfstate.*
 .terraform/
@@ -377,10 +361,3 @@ temp/
 *.backup
 *.bak
 *.tmp
-
-# Lock files
-*.lock
-!package-lock.json
-!yarn.lock
-!Pipfile.lock
-!Gemfile.lock

--- a/config/ssh/config
+++ b/config/ssh/config
@@ -17,7 +17,6 @@ Host Mufasa
 
 Host *
     # Security settings
-    Protocol 2
     ServerAliveInterval 60
     ServerAliveCountMax 3
     ControlMaster auto
@@ -36,10 +35,6 @@ Host *
     ForwardAgent no
     ForwardX11 no
 
-    # Preferred algorithms (modern/secure)
-    KexAlgorithms curve25519-sha256@libssh.org,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512
-    HostKeyAlgorithms rsa-sha2-512,rsa-sha2-256,ssh-ed25519
-    Ciphers chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr
-    MACs hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,umac-128-etm@openssh.com
+    # Let modern OpenSSH defaults negotiate secure algorithms
 
 # Additional host configurations can be added here


### PR DESCRIPTION
## Summary
- switch Git credential helper to macOS keychain ()
- fix asdf bootstrap Homebrew formula ( instead of )
- simplify SSH client config by removing legacy protocol and pinned crypto algorithm lists
- clean global gitignore to avoid suppressing common reproducibility/version files

## Why
These changes reduce brittle defaults and improve portability/security while keeping your CLI workflow intact.